### PR TITLE
Fix missing advanced features import

### DIFF
--- a/src/complete_jarvis_advanced_features.py
+++ b/src/complete_jarvis_advanced_features.py
@@ -1,0 +1,19 @@
+"""Compatibility wrapper for advanced JARVIS features."""
+
+from .advanced_jarvis_features import (
+    JarvisFormulaCalculator,
+    JarvisQueryDetector,
+    JarvisLogicGates,
+    JarvisPipeline,
+    JarvisDecisionTrees,
+    AdvancedJarvisChatbot,
+)
+
+__all__ = [
+    "JarvisFormulaCalculator",
+    "JarvisQueryDetector",
+    "JarvisLogicGates",
+    "JarvisPipeline",
+    "JarvisDecisionTrees",
+    "AdvancedJarvisChatbot",
+]


### PR DESCRIPTION
## Summary
- provide a `complete_jarvis_advanced_features` module to match imports

## Testing
- `pytest -q`
- `python test_jarvis_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684e798fdf1c832ab976fcbd2a4d1590