### PR TITLE
Ignore pycache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ Thumbs.db
 .env
 .env.local
 jarvis_simple_db/
-jarvis_comprehensive_db/ 
+jarvis_comprehensive_db/
+.pytest_cache/


### PR DESCRIPTION
## Summary
- clean up test artifacts
- ignore `__pycache__` and `.pytest_cache`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684e7d77a6d4832aa8e0db904e6acd4e